### PR TITLE
Update GitHub actions syntax based on deprecation warning.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -109,7 +109,7 @@ runs:
   using: "composite"
   steps:
     - id: setup
-      run: echo "::set-output name=directory::$(mktemp -d)"
+      run: echo "directory=$(mktemp -d)" >> $GITHUB_OUTPUT
       shell: bash
     - run: mkdir -p ${{ steps.setup.outputs.directory }}/publish
       shell: bash


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/